### PR TITLE
Fixing value format

### DIFF
--- a/lib/classes/item.php
+++ b/lib/classes/item.php
@@ -614,7 +614,7 @@ class SagepayItem
             }
             else if (is_float($value))
             {
-                $node = $basket->createElement($name, number_format($value, 2));
+                $node = $basket->createElement($name, number_format($value, 2, '.', ''));
             }
             if ($node !== null)
             {


### PR DESCRIPTION
Preventing number_format from using comma for values above 1000.

http://stackoverflow.com/questions/25968111/sagepay-xml-basket

This fixes issue #2 